### PR TITLE
[enhancement] Ability for helm charts to pass existing roleJson secret name

### DIFF
--- a/charts/tss-injector/templates/deployment.yaml
+++ b/charts/tss-injector/templates/deployment.yaml
@@ -55,7 +55,11 @@ spec:
       volumes:
         - name: roles
           secret:
+            {{- if .Values.rolesJsonSecretName }}
+            secretName: {{ .Values.rolesJsonSecretName }}
+            {{- else }}
             secretName: {{ include "tss.name" . }}-roles
+            {{- end }}
         - name: tls
           secret:
             secretName: {{ include "tss.name" . }}-tls

--- a/charts/tss-injector/templates/roles-secret.yaml
+++ b/charts/tss-injector/templates/roles-secret.yaml
@@ -1,3 +1,4 @@
+{{- if and (.Values.rolesJson) (not .Values.rolesJsonSecretName)  -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,3 +6,4 @@ metadata:
 data:
   json: {{ .Values.rolesJson | b64enc }}
 type: Opaque
+{{- end -}}

--- a/charts/tss-injector/values.yaml
+++ b/charts/tss-injector/values.yaml
@@ -64,6 +64,9 @@ webhookCertExpireDays: 1825
 # containerPort is the port that the container itself listens on
 containerPort: 18543
 
+# Secret name for rolesJson containing JSON-formatted roles file
+rolesJsonSecretName: 
+
 # rolesJson contains the JSON-formatted roles file (see README.md)
 rolesJson: >-
   {


### PR DESCRIPTION
This PR provides the ability for users to provide existing secret name containing the roleJson information. As this allows users to store the values information in gitOps fashion